### PR TITLE
fix: scroll network chain id hex issue

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -4,7 +4,7 @@ export const STORAGE_KEYS = {
 
 export const CUSTOM_CHAINS = [
   {
-    id: '534353',
+    id: '0x82751',
     name: 'Scroll Alpha Testnet',
     network: 'Scroll Alpha Testnet',
     nativeCurrency: {


### PR DESCRIPTION
`mutation.ts:261 Error: invalid hexlify value `

Some network RPC only accept hex values for chain id. As such, provide a hex value instead of base 10 