### PR TITLE
fix: custom chains not working and showing wrong network

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -4,7 +4,25 @@ export const STORAGE_KEYS = {
 
 export const CUSTOM_CHAINS = [
   {
-    id: '0x82751',
+    id: 9990,
+    name: 'Altlayer Alpha Devnet',
+    network: 'Altlayer Alpha Devnet',
+    nativeCurrency: {
+      decimals: 18,
+      name: 'ALT',
+      symbol: 'ALT',
+    },
+    rpcUrls: {
+      public: { http: ['https://devnet-rpc.altlayer.io'] },
+      default: { http: ['https://devnet-rpc.altlayer.io'] },
+    },
+    blockExplorers: {
+      default: { name: 'Devnet Explorer', url: 'https://devnet-explorer.altlayer.io/' },
+    },
+    contracts: {},
+  },
+  {
+    id: 534353,
     name: 'Scroll Alpha Testnet',
     network: 'Scroll Alpha Testnet',
     nativeCurrency: {


### PR DESCRIPTION
Fixes an issue where custom chains would show "Wrong Network"
chainId changed from string -> number

https://user-images.githubusercontent.com/29735224/229511471-88293dad-e478-4aca-b372-0061259c69ac.mp4



